### PR TITLE
Minor change to enabling network performance monitoring

### DIFF
--- a/src/Raygun/RaygunClient.h
+++ b/src/Raygun/RaygunClient.h
@@ -61,7 +61,7 @@
 // Real User Monitoring (RUM)
 
 - (void)enableRealUserMonitoring;
-- (void)enableNetworkPerformanceMonitoring:(bool)enableMonitoring;
+- (void)enableNetworkPerformanceMonitoring;
 - (void)ignoreViews:(NSArray *)viewNames;
 - (void)ignoreURLs:(NSArray *)urls;
 - (void)sendTimingEvent:(RaygunEventTimingType)type withName:(NSString *)name withDuration:(int)milliseconds;

--- a/src/Raygun/RaygunClient.m
+++ b/src/Raygun/RaygunClient.m
@@ -247,8 +247,8 @@ static RaygunLoggingLevel sharedLogLevel = kRaygunLoggingLevelError;
     [[RaygunRealUserMonitoring sharedInstance] enable];
 }
 
-- (void)enableNetworkPerformanceMonitoring:(bool)enableMonitoring {
-    [[RaygunRealUserMonitoring sharedInstance] enableNetworkPerformanceMonitoring:enableMonitoring];
+- (void)enableNetworkPerformanceMonitoring {
+    [[RaygunRealUserMonitoring sharedInstance] enableNetworkPerformanceMonitoring];
 }
 
 - (void)ignoreViews:(NSArray *)viewNames {

--- a/src/Raygun/RaygunNetworkPerformanceMonitor.h
+++ b/src/Raygun/RaygunNetworkPerformanceMonitor.h
@@ -33,7 +33,7 @@
 
 - (instancetype)init;
 
-- (void)setEnabled:(BOOL)enabled;
+- (void)enable;
 
 - (void)ignoreURLs:(NSArray *)urls;
 

--- a/src/Raygun/RaygunNetworkPerformanceMonitor.m
+++ b/src/Raygun/RaygunNetworkPerformanceMonitor.m
@@ -92,19 +92,17 @@ static RaygunSessionTaskDelegate* sessionDelegate;
     return self;
 }
 
-- (void)setEnabled:(BOOL)enable {
-    enabled = enable;
+- (void)enable {
+    enabled = true;
     
-    if (enabled) {
-        static dispatch_once_t onceToken;
-        dispatch_once(&onceToken, ^{
-            [RaygunLogger logDebug:@"Enabling network performance monitoring"];
-            [RaygunNetworkPerformanceMonitor swizzleUrlSessionTaskMethods];
-            [RaygunNetworkPerformanceMonitor swizzleUrlSessionMethods];
-            [RaygunNetworkPerformanceMonitor swizzleUrlConnectionMethods];
-            [RaygunNetworkPerformanceMonitor swizzleUrlSessionDelegateMethods];
-        });
-    }
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        [RaygunLogger logDebug:@"Enabling network performance monitoring"];
+        [RaygunNetworkPerformanceMonitor swizzleUrlSessionTaskMethods];
+        [RaygunNetworkPerformanceMonitor swizzleUrlSessionMethods];
+        [RaygunNetworkPerformanceMonitor swizzleUrlConnectionMethods];
+        [RaygunNetworkPerformanceMonitor swizzleUrlSessionDelegateMethods];
+    });
 }
 
 - (void)ignoreURLs:(NSArray *)urls {

--- a/src/Raygun/RaygunRealUserMonitoring.h
+++ b/src/Raygun/RaygunRealUserMonitoring.h
@@ -41,7 +41,7 @@
 
 - (void)enable;
 
-- (void)enableNetworkPerformanceMonitoring:(bool)enableMonitoring;
+- (void)enableNetworkPerformanceMonitoring;
 
 - (void)identifyWithUserInformation:(RaygunUserInformation *)userInformation;
 

--- a/src/Raygun/RaygunRealUserMonitoring.m
+++ b/src/Raygun/RaygunRealUserMonitoring.m
@@ -42,8 +42,8 @@
 @property (nonatomic, copy) NSString *sessionId;
 @property (nonatomic, copy) NSString *lastViewName;
 @property (nonatomic, copy) NSOperationQueue *queue;
-@property (nonatomic, copy) RaygunNetworkPerformanceMonitor * networkMonitor;
 @property (nonatomic, copy) NSMutableSet *ignoredViews;
+@property (nonatomic, copy) RaygunNetworkPerformanceMonitor * networkMonitor;
 @property (nonatomic, copy) RaygunUserInformation *currentSessionUserInformation;
 
 @end
@@ -65,9 +65,9 @@ static RaygunRealUserMonitoring *sharedInstance = nil;
 - (id)init {
     if (self = [super init]) {
         _timers         = [[NSMutableDictionary alloc] init];
-        _networkMonitor = [[RaygunNetworkPerformanceMonitor alloc] init];
         _queue          = [[NSOperationQueue alloc] init];
         _ignoredViews   = [[NSMutableSet alloc] init];
+        _networkMonitor = [[RaygunNetworkPerformanceMonitor alloc] init];
         
         [_ignoredViews addObject:@"UINavigationController"];
         [_ignoredViews addObject:@"UIInputWindowController"];
@@ -90,12 +90,12 @@ static RaygunRealUserMonitoring *sharedInstance = nil;
     });
 }
 
-- (void)enableNetworkPerformanceMonitoring:(bool)enableMonitoring {
+- (void)enableNetworkPerformanceMonitoring {
     if (!_enabled) {
         [RaygunLogger logError:@"RUM must be enabled before enabling network performance monitoring"];
         return;
     }
-    [_networkMonitor setEnabled:enableMonitoring];
+    [_networkMonitor enable];
 }
 
 #pragma mark - Application Events -


### PR DESCRIPTION
No need to pass a bool to this method. It is off by default and can be enabled by one call to enable.