### PR TITLE
[CR-258] Update the crash report property name for stack traces.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.2
+- Updated crash report property name for the stack trace
+- Additional guards against the provider generating exceptions 
+
 ## 1.4.1
 - Prefixed KSCrash classes and methods to avoid conflicts with external sources
 - The RaygunCrashReportConverter class is now public

--- a/Sources/Raygun/RaygunDefines.h
+++ b/Sources/Raygun/RaygunDefines.h
@@ -41,7 +41,7 @@
 #define RAYGUN_CAN_USE_UIKIT 0
 #endif
 
-static NSString *_Nonnull const kRaygunClientVersion = @"1.4.1";
+static NSString *_Nonnull const kRaygunClientVersion = @"1.4.2";
 
 static NSString *_Nonnull const kRaygunIdentifierUserDefaultsKey = @"com.raygun.identifier";
 static NSString *_Nonnull const kRaygunSessionLastSeenDefaultsKey = @"com.raygun.session.lastseen";

--- a/Sources/Raygun/RaygunErrorMessage.m
+++ b/Sources/Raygun/RaygunErrorMessage.m
@@ -64,7 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
     
     if (![RaygunUtils isNullOrEmpty:_stackTrace]) {
-        dict[@"managedStackTrace"] = _stackTrace;
+        dict[@"stackTrace"] = _stackTrace;
     }
     
     return dict;

--- a/Sources/Raygun/RaygunLogger.m
+++ b/Sources/Raygun/RaygunLogger.m
@@ -34,41 +34,65 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation RaygunLogger
 
 + (void)logError:(NSString *)message, ... {
-    va_list args;
-    va_start(args, message);
-    NSString *formattedMessage = [[NSString alloc] initWithFormat:message arguments:args];
-    va_end(args);
-    [RaygunLogger log:formattedMessage withLevel:RaygunLoggingLevelError];
+    @try {
+        va_list args;
+        va_start(args, message);
+        NSString *formattedMessage = [[NSString alloc] initWithFormat:message arguments:args];
+        va_end(args);
+        [RaygunLogger log:formattedMessage withLevel:RaygunLoggingLevelError];
+    }
+    @catch (NSException *exception) {
+        // Ignore
+    }
 }
 
 + (void)logWarning:(NSString *)message, ... {
-    va_list args;
-    va_start(args, message);
-    NSString *formattedMessage = [[NSString alloc] initWithFormat:message arguments:args];
-    va_end(args);
-    [RaygunLogger log:formattedMessage withLevel:RaygunLoggingLevelWarning];
+    @try {
+        va_list args;
+        va_start(args, message);
+        NSString *formattedMessage = [[NSString alloc] initWithFormat:message arguments:args];
+        va_end(args);
+        [RaygunLogger log:formattedMessage withLevel:RaygunLoggingLevelWarning];
+    }
+    @catch (NSException *exception) {
+        // Ignore
+    }
 }
 
 + (void)logDebug:(NSString *)message, ... {
-    va_list args;
-    va_start(args, message);
-    NSString *formattedMessage = [[NSString alloc] initWithFormat:message arguments:args];
-    va_end(args);
-    [RaygunLogger log:formattedMessage withLevel:RaygunLoggingLevelDebug];
+    @try {
+        va_list args;
+        va_start(args, message);
+        NSString *formattedMessage = [[NSString alloc] initWithFormat:message arguments:args];
+        va_end(args);
+        [RaygunLogger log:formattedMessage withLevel:RaygunLoggingLevelDebug];
+    }
+    @catch (NSException *exception) {
+        // Ignore
+    }
 }
 
 + (void)logResponseStatusCode:(NSInteger)statusCode {
-    NSString *message = [self ResponseStatusCodeMessage:statusCode];
-    
-    switch ((RaygunResponseStatusCode)statusCode) {
-        case RaygunResponseStatusCodeAccepted: [self logDebug:message]; break;
-            
-        case RaygunResponseStatusCodeBadMessage:    // fall through
-        case RaygunResponseStatusCodeInvalidApiKey: // fall through
-        case RaygunResponseStatusCodeLargePayload:  // fall through
-        case RaygunResponseStatusCodeRateLimited: [self logError:message]; break;
-            
-        default: [self logDebug:message]; break;
+    @try {
+        NSString *message = [self ResponseStatusCodeMessage:statusCode];
+           
+       switch ((RaygunResponseStatusCode)statusCode) {
+           case RaygunResponseStatusCodeAccepted: {
+               [self logDebug:message];
+           } break;
+               
+           case RaygunResponseStatusCodeBadMessage:    // fall through
+           case RaygunResponseStatusCodeInvalidApiKey: // fall through
+           case RaygunResponseStatusCodeLargePayload:  // fall through
+           case RaygunResponseStatusCodeRateLimited: {
+               [self logError:message];
+           } break;
+               
+           default: [self logDebug:message]; break;
+       }
+    }
+    @catch (NSException *exception) {
+        // Ignore
     }
 }
 

--- a/Sources/Raygun/RaygunRealUserMonitoring.m
+++ b/Sources/Raygun/RaygunRealUserMonitoring.m
@@ -313,7 +313,10 @@ static RaygunRealUserMonitoring *sharedInstance = nil;
             if (response != nil) {
                 @try {
                     NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*)response;
-                    [RaygunLogger logResponseStatusCode:httpResponse.statusCode];
+                    if (httpResponse != nil)
+                    {
+                        [RaygunLogger logResponseStatusCode:httpResponse.statusCode];
+                    }
                 }
                 @catch (NSException *exception) {
                     [RaygunLogger logError:@"Failed to read response code from API request"];

--- a/raygun4apple.podspec
+++ b/raygun4apple.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'raygun4apple'
-  s.version      = '1.4.1'
+  s.version      = '1.4.2'
   s.summary      = 'Raygun client for Apple platforms'
   s.homepage     = 'https://raygun.com'
   s.authors      = { 'Raygun' => 'hello@raygun.com' }

--- a/raygun4apple.xcodeproj/project.pbxproj
+++ b/raygun4apple.xcodeproj/project.pbxproj
@@ -2121,7 +2121,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BITCODE_GENERATION_MODE = marker;
-				CURRENT_PROJECT_VERSION = 1.4.1;
+				CURRENT_PROJECT_VERSION = 1.4.2;
 				GCC_PREPROCESSOR_DEFINITIONS = "Raygun_KSLogger_Level=Raygun_KSLogger_Level_None";
 				OTHER_CFLAGS = "-fembed-bitcode-marker";
 				SDKROOT = iphoneos;
@@ -2132,7 +2132,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BITCODE_GENERATION_MODE = bitcode;
-				CURRENT_PROJECT_VERSION = 1.4.1;
+				CURRENT_PROJECT_VERSION = 1.4.2;
 				GCC_PREPROCESSOR_DEFINITIONS = "Raygun_KSLogger_Level=Raygun_KSLogger_Level_None";
 				OTHER_CFLAGS = "-fembed-bitcode";
 				SDKROOT = iphoneos;


### PR DESCRIPTION
https://raygun.atlassian.net/browse/CR-258

Updated report property name for the stack trace so that it can be used by the React Native provider. The original naming was not being used and the symbolication process was adding in the stackTrace property.

Changes:
- Renamed managedStackTrace to stackTrace
- Additional guards against exceptions