### PR TITLE
[Customers Product]: Change references from 'Users' to 'Customers' within documentation 👥 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,10 @@
 ## 1.4.0
 - CocoaPods support
 - New sample app projects
-- Fix: UUID not being included by default for user information
+- Fix: UUID not being included by default for user/customer information
 
 ## 1.3.10
-- Fix for anonymous user information not being included in crash reports
+- Fix for anonymous user/customer information not being included in crash reports
 
 ## 1.3.9
 - Additional guards against internal exceptions being thrown when setting custom data

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ To ensure that the Raygun client is correctly configured, try sending a test cra
                             withCustomData:@{@"TestMessage":@"Hello World!"}];
 ```
 
-## Set up unique user tracking
+## Set up Customers
 
-By default, each user will be identified as an anonymous user. However you can set more detailed user information with the following snippet.
+By default, each user will be identified as an anonymous user/customers. However you can set more detailed customer information with the following snippet.
 
 ```objective-c
 RaygunUserInformation *userInfo = nil;


### PR DESCRIPTION
## [Customers Product]: Change references from 'User tracking' to 'Customers' within the documentation 👤

**NOTE: This is not to be merged until we have fully released the name change in the Raygun application. Changes to 'users' within the code need to be discussed and planned for.**

### Description 📝 
This PR is to updating the name convention for 'User tracking' to now be 'Customers' to reflect what's within the Raygun application.

**Updates**
👉 Update `README` documentation
👉 Update `CHANGELOG` document

### Test plan 🧪 
- Make sure documentation changes are reflected to be 'Customers' instead of 'Users' or 'User tracking'

### Checklist ✔️ 
- [ ] Builds pass
- [ ] Reviewed by another developer
- [ ] Code is written to standards