### PR TITLE
Falls back to thread stack trace if nil

### DIFF
--- a/Sources/Raygun/RaygunClient.m
+++ b/Sources/Raygun/RaygunClient.m
@@ -239,12 +239,18 @@ static RaygunLoggingLevel sharedLogLevel = RaygunLoggingLevelWarning;
     }
     
     @try {
+      
+        NSArray *trace = exception.callStackSymbols;
+        if (trace == nil) {
+            trace = [NSThread callStackSymbols];
+        }
+      
         [self updateCrashReportUserInformation];
         [Raygun_KSCrash.sharedInstance reportUserException:exception.name
                                              reason:exception.reason
                                            language:@""
                                          lineOfCode:nil
-                                         stackTrace:exception.callStackSymbols
+                                         stackTrace:trace
                                       logAllThreads:NO
                                    terminateProgram:NO];
     } @catch (NSException *exception) {

--- a/Sources/Raygun_KSCrash/Recording/Raygun_KSCrash.m
+++ b/Sources/Raygun_KSCrash/Recording/Raygun_KSCrash.m
@@ -388,7 +388,7 @@ static NSString* getBasePath()
     NSData* jsonData = [Raygun_KSJSONCodec encode:stackTrace options:0 error:&error];
     if(jsonData == nil || error != nil)
     {
-        RAYGUN_KSLOG_ERROR(@"Error encoding stack trace to JSON: %@", error);
+        RAYGUN_KSLOG_ERROR(@"Error encoding stack trace %@ to JSON: %@", stackTrace, error);
         // Don't return, since we can still record other useful information.
     }
     NSString* jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];


### PR DESCRIPTION
When you create an exception with `.init` the attached stackTrace is nil. This change falls back to the stackTrace for the current thread if that's the case