### PR TITLE
Adds include for missing ucontext64_t type

### DIFF
--- a/Sources/Raygun_KSCrash/Recording/Tools/Raygun_KSMachineContext.c
+++ b/Sources/Raygun_KSCrash/Recording/Tools/Raygun_KSMachineContext.c
@@ -37,6 +37,7 @@
 #include "Raygun_KSLogger.h"
 
 #ifdef __arm64__
+    #include <sys/_types/_ucontext64.h>
     #define UC_MCONTEXT uc_mcontext64
     typedef ucontext64_t SignalUserContext;
 #else


### PR DESCRIPTION
This fixes builds on XCode 16 on arm64.

Ref: https://github.com/getsentry/sentry-cocoa/pull/4244/files