### PR TITLE
Adds the ability to specify a groupingKeyProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,69 @@ userInfo = [[RaygunUserInformation alloc] initWithIdentifier:@"ronald@raygun.com
 RaygunClient.sharedInstance.userInformation = userInfo;
 ```
 
+## Custom Error Grouping
+
+You can provide your own grouping key if you wish. We only recommend this if you're having issues with errors not being grouped properly by Raygun's default logic.
+
+The `groupingKeyProvider` is a block (or closure in Swift) that you set on the `RaygunClient.sharedInstance`. This block is called when an error report is being prepared and it receives a `RaygunMessageDetails` object. This object contains all available information about the error, including the error message, class name, tags, custom data, user information, and the detailed thread (stack trace) information.
+
+Your block should return an `NSString` (or `String` in Swift) that will be used as the grouping key. If you return `nil` or an empty string, Raygun will revert to its default grouping logic for that error.
+
+**Important Note on Stack Traces:**
+Inside the `RaygunMessageDetails` object:
+
+- `details.error.stackTrace` (a simple array of strings) might be `nil`, especially for reports originating from crashes (KSCrash).
+- `details.threads` (an array of `RaygunThread` objects, each containing `RaygunFrame` objects) provides the rich, structured stack trace information for all reports, including crashes. If your custom grouping logic needs to inspect stack frames, you should use `details.threads`.
+
+### Objective-C Example
+
+```objective-c
+#import <raygun4apple/raygun4apple.h> // Or your specific platform import
+
+// In your AppDelegate or relevant setup code:
+RaygunClient.sharedInstance.groupingKeyProvider = ^NSString * _Nullable(RaygunMessageDetails * _Nonnull details) {
+    // Example: Group by the error's class name and the first line of the error message.
+    NSString *className = details.error.className ?: @"UnknownClass";
+    NSString *messageSummary = @"NoMessage";
+
+    if (details.error.message != nil && details.error.message.length > 0) {
+        NSArray<NSString *> *lines = [details.error.message componentsSeparatedByString:@"\n"];
+        if (lines.count > 0) {
+            messageSummary = lines[0];
+        }
+    }
+
+    // You could also inspect details.threads for stack trace information if needed.
+    // For example, to get the class and method of the top-most application frame.
+
+    return [NSString stringWithFormat:@"%@|%@", className, messageSummary];
+};
+```
+
+### Swift Example
+
+```swift
+import raygun4apple
+
+// In your AppDelegate or relevant setup code:
+RaygunClient.sharedInstance().groupingKeyProvider = { details in
+    // Example: Group by the error's class name and the first line of the error message.
+    let className = details.error?.className ?? "UnknownClass"
+    var messageSummary = "NoMessage"
+
+    if let errorMessage = details.error?.message, !errorMessage.isEmpty {
+        messageSummary = errorMessage.components(separatedBy: "\n").first ?? ""
+    }
+
+    // You could also inspect details.threads for stack trace information if needed.
+    // For example, to get the class and method of the top-most application frame.
+
+    return "\(className)|\(messageSummary)"
+}
+```
+
+This allows you to customize how errors are grouped together in the Raygun dashboard based on any data present in the `RaygunMessageDetails`.
+
 ## Documentation
 
 For more information please visit our public documentation [here](https://raygun.com/documentation/language-guides/apple/).

--- a/Sources/Raygun/RaygunClient.m
+++ b/Sources/Raygun/RaygunClient.m
@@ -58,6 +58,7 @@ static RaygunLoggingLevel sharedLogLevel = RaygunLoggingLevelWarning;
 
 @synthesize userInformation = _userInformation;
 @synthesize crashReportingApiEndpoint = _crashReportingApiEndpoint;
+@synthesize groupingKeyProvider = _groupingKeyProvider;
 
 // ============================================================================
 #pragma mark - Getters & Setters -
@@ -299,6 +300,16 @@ static RaygunLoggingLevel sharedLogLevel = RaygunLoggingLevelWarning;
 
 - (void)sendMessage:(RaygunMessage *)message {
     BOOL send = YES;
+
+    // Call groupingKeyProvider if it's set
+    if (self.groupingKeyProvider != nil && message != nil && message.details != nil) {
+        NSString *groupingKey = self.groupingKeyProvider(message.details);
+
+        if (groupingKey != nil && ![groupingKey isEqualToString:@""]) {
+            message.details.groupingKey = groupingKey;
+            [RaygunLogger logDebug:@"Applied custom grouping key from provider: %@", groupingKey];
+        }
+    }
     
     if (_beforeSendMessage != nil) {
         send = _beforeSendMessage(message);

--- a/Sources/Raygun/RaygunCrashReportConverter.m
+++ b/Sources/Raygun/RaygunCrashReportConverter.m
@@ -44,6 +44,7 @@
 #import "RaygunFrame.h"
 #import "RaygunThread.h"
 #import "RaygunBreadcrumb.h"
+#import "RaygunClient.h"
 
 #import <sys/sysctl.h>
 
@@ -130,6 +131,16 @@ NS_ASSUME_NONNULL_BEGIN
         
         if (userData[@"customData"]) {
             details.customData = userData[@"customData"];
+        }
+    }
+
+    // Call groupingKeyProvider if it's set
+    RaygunClient *clientInstance = [RaygunClient sharedInstance];
+    if (clientInstance != nil && clientInstance.groupingKeyProvider != nil && details != nil) {
+        NSString *groupingKey = clientInstance.groupingKeyProvider(details);
+
+        if (groupingKey != nil && ![groupingKey isEqualToString:@""]) {
+            details.groupingKey = groupingKey;
         }
     }
     

--- a/Sources/public/RaygunClient.h
+++ b/Sources/public/RaygunClient.h
@@ -26,6 +26,7 @@
 
 #import <Foundation/Foundation.h>
 #import "RaygunDefines.h"
+#import "RaygunMessageDetails.h"
 
 @class RaygunUserInformation, RaygunMessage, RaygunBreadcrumb;
 
@@ -35,6 +36,16 @@ NS_ASSUME_NONNULL_BEGIN
  * Block can be used to modify the crash report before it is sent to Raygun.
  */
 typedef BOOL (^RaygunBeforeSendMessage)(RaygunMessage *message);
+
+/**
+ * Block type for providing a custom grouping key for an error report.
+ * The block is passed the RaygunMessageDetails object which contains all available
+ * information about the error, environment, user, custom data, tags, and threads (including stack traces).
+ *
+ * @param details The RaygunMessageDetails object containing all context for the error.
+ * @return A string to be used as the grouping key. If nil or empty, Raygun will use its default grouping logic.
+ */
+typedef NSString * _Nullable (^RaygunGroupingKeyProviderBlock)(RaygunMessageDetails * _Nonnull details);
 
 @interface RaygunClient : NSObject
 
@@ -59,6 +70,15 @@ typedef BOOL (^RaygunBeforeSendMessage)(RaygunMessage *message);
 @property (nonatomic, assign) int maxReportsStoredOnDevice;
 
 @property (nonatomic, readonly, copy) NSArray<RaygunBreadcrumb *> *breadcrumbs;
+
+/**
+ *  Optional block that can be set to provide a custom grouping key for error reports.
+ *  This key is used by Raygun to group similar errors together.
+ *  When an error is processed, this block will be invoked with details of the error.
+ *  If this property is not set, or if the block returns nil or an empty string,
+ *  Raygun's default grouping logic will be used.
+ */
+@property (nonatomic, copy, nullable) RaygunGroupingKeyProviderBlock groupingKeyProvider;
 
 /*
  * Returns the shared Raygun client


### PR DESCRIPTION
This block is called when a message is being prepared to be sent to Raygun, and is used to allow for custom grouping in the Raygun dashboard.