### PR TITLE
chore: release version 2.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.1.6
+
+- Add synchronous storeCrashReport method for use during process termination
+- Fix race when deleting crash reports (#70)
+
 ## 2.1.5
 
 - Use @synchronized directive for breadcrumbs

--- a/Sources/public/RaygunDefines.h
+++ b/Sources/public/RaygunDefines.h
@@ -41,7 +41,7 @@
 #define RAYGUN_CAN_USE_UIKIT 0
 #endif
 
-static NSString *_Nonnull const kRaygunClientVersion = @"2.1.5";
+static NSString *_Nonnull const kRaygunClientVersion = @"2.1.6";
 
 static NSString *_Nonnull const kRaygunIdentifierUserDefaultsKey = @"com.raygun.identifier";
 static NSString *_Nonnull const kRaygunSessionLastSeenDefaultsKey = @"com.raygun.session.lastseen";

--- a/raygun4apple.podspec
+++ b/raygun4apple.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'raygun4apple'
-  s.version      = '2.1.5'
+  s.version      = '2.1.6'
   s.summary      = 'Raygun client for Apple platforms'
   s.homepage     = 'https://raygun.com'
   s.authors      = { 'Raygun' => 'hello@raygun.com' }

--- a/raygun4apple.xcodeproj/project.pbxproj
+++ b/raygun4apple.xcodeproj/project.pbxproj
@@ -2153,7 +2153,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BITCODE_GENERATION_MODE = marker;
-				CURRENT_PROJECT_VERSION = 2.1.5;
+				CURRENT_PROJECT_VERSION = 2.1.6;
 				GCC_PREPROCESSOR_DEFINITIONS = "Raygun_KSLogger_Level=Raygun_KSLogger_Level_None";
 				OTHER_CFLAGS = "-fembed-bitcode-marker";
 				SDKROOT = iphoneos;
@@ -2164,7 +2164,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BITCODE_GENERATION_MODE = bitcode;
-				CURRENT_PROJECT_VERSION = 2.1.5;
+				CURRENT_PROJECT_VERSION = 2.1.6;
 				GCC_PREPROCESSOR_DEFINITIONS = "Raygun_KSLogger_Level=Raygun_KSLogger_Level_None";
 				OTHER_CFLAGS = "-fembed-bitcode";
 				SDKROOT = iphoneos;


### PR DESCRIPTION
## Release 2.1.6

### Summary

- **New feature:** Add synchronous `storeCrashReport:` method to `RaygunClient` for use in contexts where the process is about to terminate (e.g. unhandled exception hooks) and async network requests would not complete. The report is stored to disk and sent on the next app launch.
- **Bug fix:** Fix race condition when deleting crash reports (#70)
- **Tests:** Add unit tests for `storeCrashReport:` and concurrent exception handling
- Version bump to 2.1.6 across all manifests (podspec, Xcode project, defines header, changelog)