### PR TITLE
fix: podspec warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         run: gem install cocoapods
 
       - name: Validate Podspec
-        run: pod lib lint --allow-warnings
+        run: pod lib lint
 
   build-ios-xcframework:
     name: Build iOS XCFramework

--- a/Sources/Raygun_KSCrash/Recording/Monitors/Raygun_KSCrashMonitor.c
+++ b/Sources/Raygun_KSCrash/Recording/Monitors/Raygun_KSCrashMonitor.c
@@ -202,7 +202,7 @@ void raygun_kscm_setActiveMonitors(Raygun_KSCrashMonitorType monitorTypes)
     g_activeMonitors = activeMonitors;
 }
 
-Raygun_KSCrashMonitorType raygun_kscm_getActiveMonitors()
+Raygun_KSCrashMonitorType raygun_kscm_getActiveMonitors(void)
 {
     return g_activeMonitors;
 }

--- a/Sources/Raygun_KSCrash/Recording/Monitors/Raygun_KSCrashMonitor_AppState.c
+++ b/Sources/Raygun_KSCrash/Recording/Monitors/Raygun_KSCrashMonitor_AppState.c
@@ -175,7 +175,7 @@ static int addJSONData(const char* const data, const int length, void* const use
 #pragma mark - Utility -
 // ============================================================================
 
-static double getCurentTime()
+static double getCurentTime(void)
 {
     struct timeval tv;
     gettimeofday(&tv, NULL);
@@ -333,7 +333,7 @@ void raygun_kscrashstate_initialize(const char* const stateFilePath)
     loadState(g_stateFilePath);
 }
 
-bool raygun_kscrashstate_reset()
+bool raygun_kscrashstate_reset(void)
 {
     if(g_isEnabled)
     {
@@ -451,7 +451,7 @@ static void setEnabled(bool isEnabled)
     }
 }
 
-static bool isEnabled()
+static bool isEnabled(void)
 {
     return g_isEnabled;
 }
@@ -476,7 +476,7 @@ static void addContextualInfoToEvent(Raygun_KSCrash_MonitorContext* eventContext
     }
 }
 
-Raygun_KSCrashMonitorAPI* raygun_kscm_appstate_getAPI()
+Raygun_KSCrashMonitorAPI* raygun_kscm_appstate_getAPI(void)
 {
     static Raygun_KSCrashMonitorAPI api =
     {

--- a/Sources/Raygun_KSCrash/Recording/Monitors/Raygun_KSCrashMonitor_Deadlock.m
+++ b/Sources/Raygun_KSCrash/Recording/Monitors/Raygun_KSCrashMonitor_Deadlock.m
@@ -170,7 +170,7 @@ static NSTimeInterval g_watchdogInterval = 0;
 #pragma mark - API -
 // ============================================================================
 
-static void initialize()
+static void initialize(void)
 {
     static bool isInitialized = false;
     if(!isInitialized)
@@ -200,12 +200,12 @@ static void setEnabled(bool isEnabled)
     }
 }
 
-static bool isEnabled()
+static bool isEnabled(void)
 {
     return g_isEnabled;
 }
 
-Raygun_KSCrashMonitorAPI* raygun_kscm_deadlock_getAPI()
+Raygun_KSCrashMonitorAPI* raygun_kscm_deadlock_getAPI(void)
 {
     static Raygun_KSCrashMonitorAPI api =
     {

--- a/Sources/Raygun_KSCrash/Recording/Monitors/Raygun_KSCrashMonitor_MachException.c
+++ b/Sources/Raygun_KSCrash/Recording/Monitors/Raygun_KSCrashMonitor_MachException.c
@@ -41,6 +41,7 @@
 #include <mach/mach.h>
 #include <pthread.h>
 #include <signal.h>
+#include <string.h>
 
 
 // ============================================================================
@@ -266,7 +267,7 @@ static void* handleExceptions(void* const userData)
 
     const char* threadName = (const char*) userData;
     pthread_setname_np(threadName);
-    if(threadName == kThreadSecondary)
+    if(strcmp(threadName, kThreadSecondary) == 0)
     {
         RAYGUN_KSLOG_DEBUG("This is the secondary thread. Suspending.");
         thread_suspend((thread_t)raygun_ksthread_self());
@@ -389,7 +390,7 @@ static void* handleExceptions(void* const userData)
 #pragma mark - API -
 // ============================================================================
 
-static void uninstallExceptionHandler()
+static void uninstallExceptionHandler(void)
 {
     RAYGUN_KSLOG_DEBUG("Uninstalling mach exception handler.");
     
@@ -433,7 +434,7 @@ static void uninstallExceptionHandler()
     RAYGUN_KSLOG_DEBUG("Mach exception handlers uninstalled.");
 }
 
-static bool installExceptionHandler()
+static bool installExceptionHandler(void)
 {
     RAYGUN_KSLOG_DEBUG("Installing mach exception handler.");
 
@@ -565,7 +566,7 @@ static void setEnabled(bool isEnabled)
     }
 }
 
-static bool isEnabled()
+static bool isEnabled(void)
 {
     return g_isEnabled;
 }
@@ -584,7 +585,7 @@ static void addContextualInfoToEvent(struct Raygun_KSCrash_MonitorContext* event
 
 #endif
 
-Raygun_KSCrashMonitorAPI* raygun_kscm_machexception_getAPI()
+Raygun_KSCrashMonitorAPI* raygun_kscm_machexception_getAPI(void)
 {
     static Raygun_KSCrashMonitorAPI api =
     {

--- a/Sources/Raygun_KSCrash/Recording/Monitors/Raygun_KSCrashMonitor_NSException.m
+++ b/Sources/Raygun_KSCrash/Recording/Monitors/Raygun_KSCrashMonitor_NSException.m
@@ -144,12 +144,12 @@ static void setEnabled(bool isEnabled)
     }
 }
 
-static bool isEnabled()
+static bool isEnabled(void)
 {
     return g_isEnabled;
 }
 
-Raygun_KSCrashMonitorAPI* raygun_kscm_nsexception_getAPI()
+Raygun_KSCrashMonitorAPI* raygun_kscm_nsexception_getAPI(void)
 {
     static Raygun_KSCrashMonitorAPI api =
     {

--- a/Sources/Raygun_KSCrash/Recording/Monitors/Raygun_KSCrashMonitor_Signal.c
+++ b/Sources/Raygun_KSCrash/Recording/Monitors/Raygun_KSCrashMonitor_Signal.c
@@ -118,7 +118,7 @@ static void handleSignal(int sigNum, siginfo_t* signalInfo, void* userContext)
 #pragma mark - API -
 // ============================================================================
 
-static bool installSignalHandler()
+static bool installSignalHandler(void)
 {
     RAYGUN_KSLOG_DEBUG("Installing signal handler.");
 
@@ -225,7 +225,7 @@ static void setEnabled(bool isEnabled)
     }
 }
 
-static bool isEnabled()
+static bool isEnabled(void)
 {
     return g_isEnabled;
 }
@@ -240,7 +240,7 @@ static void addContextualInfoToEvent(struct Raygun_KSCrash_MonitorContext* event
 
 #endif
 
-Raygun_KSCrashMonitorAPI* raygun_kscm_signal_getAPI()
+Raygun_KSCrashMonitorAPI* raygun_kscm_signal_getAPI(void)
 {
     static Raygun_KSCrashMonitorAPI api =
     {

--- a/Sources/Raygun_KSCrash/Recording/Monitors/Raygun_KSCrashMonitor_System.m
+++ b/Sources/Raygun_KSCrash/Recording/Monitors/Raygun_KSCrashMonitor_System.m
@@ -233,7 +233,7 @@ static const char* uuidBytesToString(const uint8_t* uuidBytes)
  *
  * @return Executable path.
  */
-static NSString* getExecutablePath()
+static NSString* getExecutablePath(void)
 {
     NSBundle* mainBundle = [NSBundle mainBundle];
     NSDictionary* infoDict = [mainBundle infoDictionary];
@@ -246,7 +246,7 @@ static NSString* getExecutablePath()
  *
  * @return The UUID.
  */
-static const char* getAppUUID()
+static const char* getAppUUID(void)
 {
     const char* result = nil;
     
@@ -305,7 +305,7 @@ static const char* getCPUArchForCPUType(cpu_type_t cpuType, cpu_subtype_t subTyp
     return NULL;
 }
 
-static const char* getCurrentCPUArch()
+static const char* getCurrentCPUArch(void)
 {
     const char* result = getCPUArchForCPUType(raygun_kssysctl_int32ForName("hw.cputype"),
                                             raygun_kssysctl_int32ForName("hw.cpusubtype"));
@@ -321,7 +321,7 @@ static const char* getCurrentCPUArch()
  *
  * @return YES if the device is jailbroken.
  */
-static bool isJailbroken()
+static bool isJailbroken(void)
 {
     return raygun_ksdl_imageNamed("MobileSubstrate", false) != UINT32_MAX;
 }
@@ -330,7 +330,7 @@ static bool isJailbroken()
  *
  * @return YES if the app was built in debug mode.
  */
-static bool isDebugBuild()
+static bool isDebugBuild(void)
 {
 #ifdef DEBUG
     return YES;
@@ -343,7 +343,7 @@ static bool isDebugBuild()
  *
  * @return YES if this is a simulator build.
  */
-static bool isSimulatorBuild()
+static bool isSimulatorBuild(void)
 {
 #if TARGET_OS_SIMULATOR
     return YES;
@@ -356,7 +356,7 @@ static bool isSimulatorBuild()
  *
  * @return App Store receipt for iOS 7+, nil otherwise.
  */
-static NSString* getReceiptUrlPath()
+static NSString* getReceiptUrlPath(void)
 {
     NSString* path = nil;
 #if RAYGUN_KSCRASH_HOST_IOS
@@ -380,7 +380,7 @@ static NSString* getReceiptUrlPath()
  *
  * @return The stringified hex representation of the hash for this device + app.
  */
-static const char* getDeviceAndAppHash()
+static const char* getDeviceAndAppHash(void)
 {
     NSMutableData* data = nil;
     
@@ -428,7 +428,7 @@ static const char* getDeviceAndAppHash()
  *
  * @return YES if this is a testing build.
  */
-static bool isTestBuild()
+static bool isTestBuild(void)
 {
     return [getReceiptUrlPath().lastPathComponent isEqualToString:@"sandboxReceipt"];
 }
@@ -438,7 +438,7 @@ static bool isTestBuild()
  *
  * @return YES if there is an app store receipt.
  */
-static bool hasAppStoreReceipt()
+static bool hasAppStoreReceipt(void)
 {
     NSString* receiptPath = getReceiptUrlPath();
     if(receiptPath == nil)
@@ -451,7 +451,7 @@ static bool hasAppStoreReceipt()
     return isAppStoreReceipt && receiptExists;
 }
 
-static const char* getBuildType()
+static const char* getBuildType(void)
 {
     if(isSimulatorBuild())
     {
@@ -472,7 +472,7 @@ static const char* getBuildType()
     return "unknown";
 }
 
-static uint64_t getStorageSize()
+static uint64_t getStorageSize(void)
 {
     NSNumber* storageSize = [[[NSFileManager defaultManager] attributesOfFileSystemForPath:NSHomeDirectory() error:nil] objectForKey:NSFileSystemSize];
     return storageSize.unsignedLongLongValue;
@@ -482,7 +482,7 @@ static uint64_t getStorageSize()
 #pragma mark - API -
 // ============================================================================
 
-static void initialize()
+static void initialize(void)
 {
     static bool isInitialized = false;
     if(!isInitialized)
@@ -575,7 +575,7 @@ static void setEnabled(bool isEnabled)
     }
 }
 
-static bool isEnabled()
+static bool isEnabled(void)
 {
     return g_isEnabled;
 }
@@ -619,7 +619,7 @@ static void addContextualInfoToEvent(Raygun_KSCrash_MonitorContext* eventContext
     }
 }
 
-Raygun_KSCrashMonitorAPI* raygun_kscm_system_getAPI()
+Raygun_KSCrashMonitorAPI* raygun_kscm_system_getAPI(void)
 {
     static Raygun_KSCrashMonitorAPI api =
     {

--- a/Sources/Raygun_KSCrash/Recording/Monitors/Raygun_KSCrashMonitor_User.c
+++ b/Sources/Raygun_KSCrash/Recording/Monitors/Raygun_KSCrashMonitor_User.c
@@ -103,12 +103,12 @@ static void setEnabled(bool isEnabled)
     g_isEnabled = isEnabled;
 }
 
-static bool isEnabled()
+static bool isEnabled(void)
 {
     return g_isEnabled;
 }
 
-Raygun_KSCrashMonitorAPI* raygun_kscm_user_getAPI()
+Raygun_KSCrashMonitorAPI* raygun_kscm_user_getAPI(void)
 {
     static Raygun_KSCrashMonitorAPI api =
     {

--- a/Sources/Raygun_KSCrash/Recording/Monitors/Raygun_KSCrashMonitor_Zombie.c
+++ b/Sources/Raygun_KSCrash/Recording/Monitors/Raygun_KSCrashMonitor_Zombie.c
@@ -139,7 +139,7 @@ static void handleDealloc_ ## CLASS(id self, SEL _cmd) \
     fn f = (fn)g_originalDealloc_ ## CLASS; \
     f(self, _cmd); \
 } \
-static void installDealloc_ ## CLASS() \
+static void installDealloc_ ## CLASS(void) \
 { \
     Method method = class_getInstanceMethod(objc_getClass(#CLASS), sel_registerName("dealloc")); \
     g_originalDealloc_ ## CLASS = method_getImplementation(method); \
@@ -154,7 +154,7 @@ static void installDealloc_ ## CLASS() \
 CREATE_ZOMBIE_HANDLER_INSTALLER(NSObject)
 CREATE_ZOMBIE_HANDLER_INSTALLER(NSProxy)
 
-static void install()
+static void install(void)
 {
     unsigned cacheSize = CACHE_SIZE;
     g_zombieHashMask = cacheSize - 1;
@@ -224,7 +224,7 @@ static void setEnabled(bool isEnabled)
     }
 }
 
-static bool isEnabled()
+static bool isEnabled(void)
 {
     return g_isEnabled;
 }
@@ -239,7 +239,7 @@ static void addContextualInfoToEvent(Raygun_KSCrash_MonitorContext* eventContext
     }
 }
 
-Raygun_KSCrashMonitorAPI* raygun_kscm_zombie_getAPI()
+Raygun_KSCrashMonitorAPI* raygun_kscm_zombie_getAPI(void)
 {
     static Raygun_KSCrashMonitorAPI api =
     {

--- a/Sources/Raygun_KSCrash/Recording/Raygun_KSCrash.m
+++ b/Sources/Raygun_KSCrash/Recording/Raygun_KSCrash.m
@@ -58,7 +58,7 @@
 @end
 
 
-static NSString* getBundleName()
+static NSString* getBundleName(void)
 {
     NSString* bundleName = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleName"];
     if(bundleName == nil)
@@ -68,7 +68,7 @@ static NSString* getBundleName()
     return bundleName;
 }
 
-static NSString* getBasePath()
+static NSString* getBasePath(void)
 {
     NSArray* directories = NSSearchPathForDirectoriesInDomains(NSCachesDirectory,
                                                                NSUserDomainMask,

--- a/Sources/Raygun_KSCrash/Recording/Raygun_KSCrashC.c
+++ b/Sources/Raygun_KSCrash/Recording/Raygun_KSCrashC.c
@@ -250,7 +250,7 @@ void raygun_kscrash_notifyAppCrash(void)
     raygun_kscrashstate_notifyAppCrash();
 }
 
-int raygun_kscrash_getReportCount()
+int raygun_kscrash_getReportCount(void)
 {
     return raygun_kscrs_getReportCount();
 }
@@ -290,7 +290,7 @@ int64_t raygun_kscrash_addUserReport(const char* report, int reportLength)
     return raygun_kscrs_addUserReport(report, reportLength);
 }
 
-void raygun_kscrash_deleteAllReports()
+void raygun_kscrash_deleteAllReports(void)
 {
     raygun_kscrs_deleteAllReports();
 }

--- a/Sources/Raygun_KSCrash/Recording/Raygun_KSCrashCachedData.c
+++ b/Sources/Raygun_KSCrash/Recording/Raygun_KSCrashCachedData.c
@@ -55,7 +55,7 @@ static _Atomic(int) g_semaphoreCount;
 static bool g_searchQueueNames = false;
 static bool g_hasThreadStarted = false;
 
-static void updateThreadList()
+static void updateThreadList(void)
 {
     const task_t thisTask = mach_task_self();
     int oldThreadsCount = g_allThreadsCount;
@@ -185,7 +185,7 @@ void raygun_ksccd_init(int pollingIntervalInSeconds)
     pthread_attr_destroy(&attr);
 }
 
-void raygun_ksccd_freeze()
+void raygun_ksccd_freeze(void)
 {
     if(g_semaphoreCount++ <= 0)
     {
@@ -194,7 +194,7 @@ void raygun_ksccd_freeze()
     }
 }
 
-void raygun_ksccd_unfreeze()
+void raygun_ksccd_unfreeze(void)
 {
     if(--g_semaphoreCount < 0)
     {

--- a/Sources/Raygun_KSCrash/Recording/Raygun_KSCrashReportStore.c
+++ b/Sources/Raygun_KSCrash/Recording/Raygun_KSCrashReportStore.c
@@ -61,7 +61,7 @@ static int compareInt64(const void* a, const void* b)
     return 0;
 }
 
-static inline int64_t getNextUniqueID()
+static inline int64_t getNextUniqueID(void)
 {
     return g_nextUniqueIDHigh + g_nextUniqueIDLow++;
 }
@@ -82,7 +82,7 @@ static int64_t getReportIDFromFilename(const char* filename)
     return reportID;
 }
 
-static int getReportCount()
+static int getReportCount(void)
 {
     int count = 0;
     DIR* dir = opendir(g_reportsPath);
@@ -138,7 +138,7 @@ done:
     return index;
 }
 
-static void pruneReports()
+static void pruneReports(void)
 {
     int reportCount = getReportCount();
     if(reportCount > g_maxReportCount)
@@ -153,7 +153,7 @@ static void pruneReports()
     }
 }
 
-static void initializeIDs()
+static void initializeIDs(void)
 {
     time_t rawTime;
     time(&rawTime);
@@ -189,7 +189,7 @@ void raygun_kscrs_getNextCrashReportPath(char* crashReportPathBuffer)
     getCrashReportPathByID(getNextUniqueID(), crashReportPathBuffer);
 }
 
-int raygun_kscrs_getReportCount()
+int raygun_kscrs_getReportCount(void)
 {
     pthread_mutex_lock(&g_mutex);
     int count = getReportCount();
@@ -251,7 +251,7 @@ done:
     return currentID;
 }
 
-void raygun_kscrs_deleteAllReports()
+void raygun_kscrs_deleteAllReports(void)
 {
     pthread_mutex_lock(&g_mutex);
     raygun_ksfu_deleteContentsOfPath(g_reportsPath);

--- a/Sources/Raygun_KSCrash/Recording/Tools/Raygun_KSDynamicLinker.c
+++ b/Sources/Raygun_KSCrash/Recording/Tools/Raygun_KSDynamicLinker.c
@@ -296,7 +296,7 @@ bool raygun_ksdl_dladdr(const uintptr_t address, Dl_info* const info)
     return true;
 }
 
-int raygun_ksdl_imageCount()
+int raygun_ksdl_imageCount(void)
 {
     return (int)_dyld_image_count();
 }

--- a/Sources/Raygun_KSCrash/Recording/Tools/Raygun_KSLogger.c
+++ b/Sources/Raygun_KSCrash/Recording/Tools/Raygun_KSLogger.c
@@ -247,7 +247,7 @@ bool raygun_kslog_setLogFilename(const char* filename, bool overwrite)
 
 #endif
 
-bool raygun_kslog_clearLogFile()
+bool raygun_kslog_clearLogFile(void)
 {
     return raygun_kslog_setLogFilename(g_logFilename, true);
 }

--- a/Sources/Raygun_KSCrash/Recording/Tools/Raygun_KSMachineContext.c
+++ b/Sources/Raygun_KSCrash/Recording/Tools/Raygun_KSMachineContext.c
@@ -97,7 +97,7 @@ static inline bool getThreadList(Raygun_KSMachineContext* context)
     return true;
 }
 
-int raygun_ksmc_contextSize()
+int raygun_ksmc_contextSize(void)
 {
     return sizeof(Raygun_KSMachineContext);
 }
@@ -167,7 +167,7 @@ static inline bool isThreadInList(thread_t thread, KSThread* list, int listCount
 }
 #endif
 
-void raygun_ksmc_suspendEnvironment()
+void raygun_ksmc_suspendEnvironment(void)
 {
 #if RAYGUN_KSCRASH_HAS_THREADS_API
     RAYGUN_KSLOG_DEBUG("Suspending environment.");
@@ -206,7 +206,7 @@ void raygun_ksmc_suspendEnvironment()
 #endif
 }
 
-void raygun_ksmc_resumeEnvironment()
+void raygun_ksmc_resumeEnvironment(void)
 {
 #if RAYGUN_KSCRASH_HAS_THREADS_API
     RAYGUN_KSLOG_DEBUG("Resuming environment.");

--- a/Sources/Raygun_KSCrash/Recording/Tools/Raygun_KSThread.c
+++ b/Sources/Raygun_KSCrash/Recording/Tools/Raygun_KSThread.c
@@ -39,7 +39,7 @@
 #include <sys/sysctl.h>
 
 
-KSThread raygun_ksthread_self()
+KSThread raygun_ksthread_self(void)
 {
     thread_t thread_self = mach_thread_self();
     mach_port_deallocate(mach_task_self(), thread_self);


### PR DESCRIPTION
## Summary

Fixed podspec warnings and enabled strict linting in CI.
- Fix all C/ObjC `-Wstrict-prototypes` warnings in vendored KSCrash code by changing empty `()` parameter lists to `(void)` (~55 functions across 16 files)
- Fix `-Wstring-compare` warning by replacing pointer comparison against a string literal with `strcmp()` in `Raygun_KSCrashMonitor_MachException.c`
- Remove `--allow-warnings` from `pod lib lint` in CI so warnings will fail the build going forward